### PR TITLE
Fixing up the docs and the test/Directory.Build.props

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -2,8 +2,6 @@
 
 The following is a set of guidelines for contributing to TerraFX.
 
-[![Gitter](https://badges.gitter.im/terrafx/terrafx.svg)](https://gitter.im/terrafx/terrafx?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge)
-
 ## Table of Contents
 
 * [Code of Conduct](#code-of-conduct)
@@ -16,24 +14,24 @@ The following is a set of guidelines for contributing to TerraFX.
 ### Code of Conduct
 
 TerraFX and everyone contributing (this includes issues, pull requests, the
-wiki, etc) must abide by the [CODE_OF_CONDUCT](docs/CODE_OF_CONDUCT.md).
+wiki, etc) must abide by the [CODE_OF_CONDUCT](CODE_OF_CONDUCT.md).
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
 reported by contacting the project team at admin@terrafx.dev.
 
 ### License
 
 Copyright © Tanner Gooding and Contributors. Licensed under the MIT License
-(MIT). See [LICENSE](LICENSE.md) in the repository root for more information.
+(MIT). See [LICENSE](../LICENSE.md) in the repository root for more information.
 
 ### What should I know?
 
 Most of the basics of the project, such as what it is about, and its goals are
-covered in our [README](docs/README.md).
+covered in our [README](README.md).
 
 ### Pull Requests
 
 All pull requests should follow our
-[PULL_REQUEST_TEMPLATE](docs/PULL_REQUEST_TEMPALTE.md). It is additionally
+[PULL_REQUEST_TEMPLATE](PULL_REQUEST_TEMPLATE.md). It is additionally
 recommended that an issue be opened, discussed, and approved first to ensure
 that the change will be accepted. Any pull requests not following pull request
 template will be requested to be updated. Any pull requests opened without a

--- a/docs/ISSUE_TEMPLATE.md
+++ b/docs/ISSUE_TEMPLATE.md
@@ -16,7 +16,7 @@ before submitting.
 ### Code of Conduct
 
 TerraFX and everyone contributing (this includes issues, pull requests, the
-wiki, etc) must abide by the [CODE_OF_CONDUCT](docs/CODE_OF_CONDUCT.md).
+wiki, etc) must abide by the [CODE_OF_CONDUCT](CODE_OF_CONDUCT.md).
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
 reported by contacting the project team at admin@terrafx.dev.
 

--- a/docs/PULL_REQUEST_TEMPLATE.md
+++ b/docs/PULL_REQUEST_TEMPLATE.md
@@ -14,7 +14,7 @@ before submitting.
 ### Code of Conduct
 
 TerraFX and everyone contributing (this includes issues, pull requests, the
-wiki, etc) must abide by the [CODE_OF_CONDUCT](docs/CODE_OF_CONDUCT.md).
+wiki, etc) must abide by the [CODE_OF_CONDUCT](CODE_OF_CONDUCT.md).
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
 reported by contacting the project team at admin@terrafx.dev.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -4,12 +4,12 @@ Interop bindings for Vulkan.
 
 | Job | Debug Status | Release Status |
 | --- | ------------ | -------------- |
-| Windows x86 | [![Build Status](https://dev.azure.com/tagoo/terrafx/_apis/build/status/terrafx.terrafx.interop.vulkan-ci?branchName=master&jobName=windows_debug_x86)](https://dev.azure.com/tagoo/terrafx/_build/latest?definitionId=2&branchName=master) | [![Build Status](https://dev.azure.com/tagoo/terrafx/_apis/build/status/terrafx.terrafx.interop.vulkan-ci?branchName=master&jobName=windows_release_x86)](https://dev.azure.com/tagoo/terrafx/_build/latest?definitionId=2&branchName=master) |
-| Windows x64 | [![Build Status](https://dev.azure.com/tagoo/terrafx/_apis/build/status/terrafx.terrafx.interop.vulkan-ci?branchName=master&jobName=windows_debug_x64)](https://dev.azure.com/tagoo/terrafx/_build/latest?definitionId=2&branchName=master) | [![Build Status](https://dev.azure.com/tagoo/terrafx/_apis/build/status/terrafx.terrafx.interop.vulkan-ci?branchName=master&jobName=windows_release_x64)](https://dev.azure.com/tagoo/terrafx/_build/latest?definitionId=2&branchName=master) |
-| Ubuntu 16.04 x64 | [![Build Status](https://dev.azure.com/tagoo/terrafx/_apis/build/status/terrafx.terrafx.interop.vulkan-ci?branchName=master&jobName=ubuntu_1604_debug_x64)](https://dev.azure.com/tagoo/terrafx/_build/latest?definitionId=2&branchName=master) | [![Build Status](https://dev.azure.com/tagoo/terrafx/_apis/build/status/terrafx.terrafx.interop.vulkan-ci?branchName=master&jobName=ubuntu_1604_release_x64)](https://dev.azure.com/tagoo/terrafx/_build/latest?definitionId=2&branchName=master) |
-| MacOS x64 | [![Build Status](https://dev.azure.com/tagoo/terrafx/_apis/build/status/terrafx.terrafx.interop.vulkan-ci?branchName=master&jobName=macos_debug_x64)](https://dev.azure.com/tagoo/terrafx/_build/latest?definitionId=2&branchName=master) | [![Build Status](https://dev.azure.com/tagoo/terrafx/_apis/build/status/terrafx.terrafx.interop.vulkan-ci?branchName=master&jobName=macos_release_x64)](https://dev.azure.com/tagoo/terrafx/_build/latest?definitionId=2&branchName=master) |
+| Windows x86 | [![Build Status](https://ci.terrafx.dev/_apis/build/status/terrafx.terrafx.interop.vulkan-ci?branchName=master&jobName=windows_debug_x86)](https://ci.terrafx.dev/_build/latest?definitionId=2&branchName=master) | [![Build Status](https://ci.terrafx.dev/_apis/build/status/terrafx.terrafx.interop.vulkan-ci?branchName=master&jobName=windows_release_x86)](https://ci.terrafx.dev/_build/latest?definitionId=2&branchName=master) |
+| Windows x64 | [![Build Status](https://ci.terrafx.dev/_apis/build/status/terrafx.terrafx.interop.vulkan-ci?branchName=master&jobName=windows_debug_x64)](https://ci.terrafx.dev/_build/latest?definitionId=2&branchName=master) | [![Build Status](https://ci.terrafx.dev/_apis/build/status/terrafx.terrafx.interop.vulkan-ci?branchName=master&jobName=windows_release_x64)](https://ci.terrafx.dev/_build/latest?definitionId=2&branchName=master) |
+| Ubuntu 16.04 x64 | [![Build Status](https://ci.terrafx.dev/_apis/build/status/terrafx.terrafx.interop.vulkan-ci?branchName=master&jobName=ubuntu_1604_debug_x64)](https://ci.terrafx.dev/_build/latest?definitionId=2&branchName=master) | [![Build Status](https://ci.terrafx.dev/_apis/build/status/terrafx.terrafx.interop.vulkan-ci?branchName=master&jobName=ubuntu_1604_release_x64)](https://ci.terrafx.dev/_build/latest?definitionId=2&branchName=master) |
+| MacOS x64 | [![Build Status](https://ci.terrafx.dev/_apis/build/status/terrafx.terrafx.interop.vulkan-ci?branchName=master&jobName=macos_debug_x64)](https://ci.terrafx.dev/_build/latest?definitionId=2&branchName=master) | [![Build Status](https://ci.terrafx.dev/_apis/build/status/terrafx.terrafx.interop.vulkan-ci?branchName=master&jobName=macos_release_x64)](https://ci.terrafx.dev/_build/latest?definitionId=2&branchName=master) |
 
-[![Gitter](https://badges.gitter.im/terrafx/terrafx.svg)](https://gitter.im/terrafx/terrafx?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge)
+[![Discord](https://img.shields.io/discord/593547387457372212.svg?label=Discord&style=plastic)](https://discord.terrafx.dev/)
 
 ## Table of Contents
 
@@ -22,14 +22,14 @@ Interop bindings for Vulkan.
 ### Code of Conduct
 
 TerraFX and everyone contributing (this includes issues, pull requests, the
-wiki, etc) must abide by the [CODE_OF_CONDUCT](docs/CODE_OF_CONDUCT.md).
+wiki, etc) must abide by the [CODE_OF_CONDUCT](CODE_OF_CONDUCT.md).
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
 reported by contacting the project team at admin@terrafx.dev.
 
 ### License
 
 Copyright © Tanner Gooding and Contributors. Licensed under the MIT License
-(MIT). See [LICENSE](LICENSE.md) in the repository root for more information.
+(MIT). See [LICENSE](../LICENSE.md) in the repository root for more information.
 
 ### Contributing
 

--- a/tests/Directory.Build.props
+++ b/tests/Directory.Build.props
@@ -12,15 +12,15 @@
 
   <PropertyGroup>
     <MSBuildAllProjects>$(MSBuildAllProjects);$(MSBuildThisFileDirectory)..\Directory.Build.props</MSBuildAllProjects>
-  </PropertyGroup>
-
-  <PropertyGroup>
     <TerraFXProjectCategory>tests</TerraFXProjectCategory>
-    <VSTestLogger>trx</VSTestLogger>
-    <VSTestResultsDirectory>$(BaseArtifactsPath)tst/$(Configuration)/</VSTestResultsDirectory>
   </PropertyGroup>
 
   <Import Project="$(MSBuildThisFileDirectory)..\Directory.Build.props" />
+
+  <PropertyGroup>
+    <VSTestLogger>trx</VSTestLogger>
+    <VSTestResultsDirectory>$(BaseArtifactsPath)tst/$(Configuration)/</VSTestResultsDirectory>
+  </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" IsImplicitlyDefined="true" />


### PR DESCRIPTION
This fixes up several links in the documentation files, adds a link to the Discord server, and fixes up the test/Directory.Build.props so that the test results directory is correct.