### PR TITLE
Updating the version to 1.0.51 to match the vulkan API version

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -41,7 +41,7 @@
     <Company>TerraFX</Company>
     <PackageOutputPath>$(BaseArtifactsPath)pkg/$(Configuration)/</PackageOutputPath>
     <Product>TerraFX.Interop.Vulkan</Product>
-    <VersionPrefix>0.1.0</VersionPrefix>
+    <VersionPrefix>1.0.51</VersionPrefix>
     <VersionSuffix>alpha</VersionSuffix>
     <VersionSuffix Condition="'$(SYSTEM_PULLREQUEST_PULLREQUESTNUMBER)' != ''">pr$(SYSTEM_PULLREQUEST_PULLREQUESTNUMBER)</VersionSuffix>
   </PropertyGroup>


### PR DESCRIPTION
This updates the version to 1.0.51 to match the source version that bindings were generated from.