### PR TITLE
Fixing some definitions in the vulkan_xlib and vulkan_xlib_xrandr headers.

### DIFF
--- a/sources/Interop/Vulkan/vulkan_xlib/PFN_vkGetPhysicalDeviceXlibPresentationSupportKHR.cs
+++ b/sources/Interop/Vulkan/vulkan_xlib/PFN_vkGetPhysicalDeviceXlibPresentationSupportKHR.cs
@@ -10,5 +10,5 @@ namespace TerraFX.Interop
 {
     [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
     [return: NativeTypeName("VkBool32")]
-    public unsafe delegate uint PFN_vkGetPhysicalDeviceXlibPresentationSupportKHR([NativeTypeName("VkPhysicalDevice")] IntPtr physicalDevice, [NativeTypeName("uint32_t")] uint queueFamilyIndex, [NativeTypeName("Display *")] IntPtr dpy, [NativeTypeName("VisualID")] uint visualID);
+    public unsafe delegate uint PFN_vkGetPhysicalDeviceXlibPresentationSupportKHR([NativeTypeName("VkPhysicalDevice")] IntPtr physicalDevice, [NativeTypeName("uint32_t")] uint queueFamilyIndex, [NativeTypeName("Display *")] UIntPtr dpy, [NativeTypeName("VisualID")] UIntPtr visualID);
 }

--- a/sources/Interop/Vulkan/vulkan_xlib/VkXlibSurfaceCreateInfoKHR.cs
+++ b/sources/Interop/Vulkan/vulkan_xlib/VkXlibSurfaceCreateInfoKHR.cs
@@ -18,9 +18,9 @@ namespace TerraFX.Interop
         public uint flags;
 
         [NativeTypeName("Display *")]
-        public IntPtr dpy;
+        public UIntPtr dpy;
 
         [NativeTypeName("Window")]
-        public uint window;
+        public UIntPtr window;
     }
 }

--- a/sources/Interop/Vulkan/vulkan_xlib/Vulkan.Manual.cs
+++ b/sources/Interop/Vulkan/vulkan_xlib/Vulkan.Manual.cs
@@ -10,6 +10,7 @@ namespace TerraFX.Interop
     public static unsafe partial class Vulkan
     {
         public const int VK_KHR_xlib_surface = 1;
+
         public const int VK_KHR_XLIB_SURFACE_SPEC_VERSION = 6;
 
         // VK_KHR_xlib_surface

--- a/sources/Interop/Vulkan/vulkan_xlib/Vulkan.cs
+++ b/sources/Interop/Vulkan/vulkan_xlib/Vulkan.cs
@@ -15,6 +15,6 @@ namespace TerraFX.Interop
 
         [DllImport(libraryPath, EntryPoint = "vkGetPhysicalDeviceXlibPresentationSupportKHR", CallingConvention = CallingConvention.Cdecl)]
         [return: NativeTypeName("VkBool32")]
-        public static extern uint vkGetPhysicalDeviceXlibPresentationSupportKHR([NativeTypeName("VkPhysicalDevice")] IntPtr physicalDevice, [NativeTypeName("uint32_t")] uint queueFamilyIndex, [NativeTypeName("Display *")] IntPtr dpy, [NativeTypeName("VisualID")] uint visualID);
+        public static extern uint vkGetPhysicalDeviceXlibPresentationSupportKHR([NativeTypeName("VkPhysicalDevice")] IntPtr physicalDevice, [NativeTypeName("uint32_t")] uint queueFamilyIndex, [NativeTypeName("Display *")] UIntPtr dpy, [NativeTypeName("VisualID")] UIntPtr visualID);
     }
 }

--- a/sources/Interop/Vulkan/vulkan_xlib_xrandr/PFN_vkAcquireXlibDisplayEXT.cs
+++ b/sources/Interop/Vulkan/vulkan_xlib_xrandr/PFN_vkAcquireXlibDisplayEXT.cs
@@ -9,5 +9,5 @@ using System.Runtime.InteropServices;
 namespace TerraFX.Interop
 {
     [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-    public unsafe delegate VkResult PFN_vkAcquireXlibDisplayEXT([NativeTypeName("VkPhysicalDevice")] IntPtr physicalDevice, [NativeTypeName("Display *")] IntPtr dpy, [NativeTypeName("VkDisplayKHR")] ulong display);
+    public unsafe delegate VkResult PFN_vkAcquireXlibDisplayEXT([NativeTypeName("VkPhysicalDevice")] IntPtr physicalDevice, [NativeTypeName("Display *")] UIntPtr dpy, [NativeTypeName("VkDisplayKHR")] ulong display);
 }

--- a/sources/Interop/Vulkan/vulkan_xlib_xrandr/PFN_vkGetRandROutputDisplayEXT.cs
+++ b/sources/Interop/Vulkan/vulkan_xlib_xrandr/PFN_vkGetRandROutputDisplayEXT.cs
@@ -9,5 +9,5 @@ using System.Runtime.InteropServices;
 namespace TerraFX.Interop
 {
     [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-    public unsafe delegate VkResult PFN_vkGetRandROutputDisplayEXT([NativeTypeName("VkPhysicalDevice")] IntPtr physicalDevice, [NativeTypeName("Display *")] IntPtr dpy, [NativeTypeName("RROutput")] uint rrOutput, [NativeTypeName("VkDisplayKHR *")] ulong* pDisplay);
+    public unsafe delegate VkResult PFN_vkGetRandROutputDisplayEXT([NativeTypeName("VkPhysicalDevice")] IntPtr physicalDevice, [NativeTypeName("Display *")] UIntPtr dpy, [NativeTypeName("RROutput")] uint rrOutput, [NativeTypeName("VkDisplayKHR *")] ulong* pDisplay);
 }

--- a/sources/Interop/Vulkan/vulkan_xlib_xrandr/Vulkan.cs
+++ b/sources/Interop/Vulkan/vulkan_xlib_xrandr/Vulkan.cs
@@ -11,9 +11,9 @@ namespace TerraFX.Interop
     public static unsafe partial class Vulkan
     {
         [DllImport(libraryPath, EntryPoint = "vkAcquireXlibDisplayEXT", CallingConvention = CallingConvention.Cdecl)]
-        public static extern VkResult vkAcquireXlibDisplayEXT([NativeTypeName("VkPhysicalDevice")] IntPtr physicalDevice, [NativeTypeName("Display *")] IntPtr dpy, [NativeTypeName("VkDisplayKHR")] ulong display);
+        public static extern VkResult vkAcquireXlibDisplayEXT([NativeTypeName("VkPhysicalDevice")] IntPtr physicalDevice, [NativeTypeName("Display *")] UIntPtr dpy, [NativeTypeName("VkDisplayKHR")] ulong display);
 
         [DllImport(libraryPath, EntryPoint = "vkGetRandROutputDisplayEXT", CallingConvention = CallingConvention.Cdecl)]
-        public static extern VkResult vkGetRandROutputDisplayEXT([NativeTypeName("VkPhysicalDevice")] IntPtr physicalDevice, [NativeTypeName("Display *")] IntPtr dpy, [NativeTypeName("RROutput")] uint rrOutput, [NativeTypeName("VkDisplayKHR *")] ulong* pDisplay);
+        public static extern VkResult vkGetRandROutputDisplayEXT([NativeTypeName("VkPhysicalDevice")] IntPtr physicalDevice, [NativeTypeName("Display *")] UIntPtr dpy, [NativeTypeName("RROutput")] uint rrOutput, [NativeTypeName("VkDisplayKHR *")] ulong* pDisplay);
     }
 }


### PR DESCRIPTION
This fixes the Window and VisualID definitions to be UIntPtr to match the `unsigned long` used in the native headers. It also updates `Display` to be UIntPtr to match the type used by TerraFX.Interop.Xlib