### PR TITLE
Adding a DllImportResolver for the vulkan native library

### DIFF
--- a/sources/Interop/Vulkan/Vulkan.cs
+++ b/sources/Interop/Vulkan/Vulkan.cs
@@ -1,9 +1,30 @@
 // Copyright © Tanner Gooding and Contributors. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
 
+using System;
+using System.Reflection;
+using System.Runtime.InteropServices;
+
 namespace TerraFX.Interop
 {
     public static unsafe partial class Vulkan
     {
         private const string libraryPath = "vulkan";
+
+        static Vulkan()
+        {
+            NativeLibrary.SetDllImportResolver(Assembly.GetExecutingAssembly(), ResolveLibrary);
+        }
+
+        private static IntPtr ResolveLibrary(string libraryName, Assembly assembly, DllImportSearchPath? searchPath)
+        {
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                return NativeLibrary.Load("vulkan-1.dll", assembly, searchPath);
+            }
+            else
+            {
+                return NativeLibrary.Load("libvulkan.so.1", assembly, searchPath);
+            }
+        }
     }
 }


### PR DESCRIPTION
This adds a DllImportResolver by default so that vulkan can be resolved despite having a different library name on Windows vs Unix.